### PR TITLE
Fix BepInEx.Analyzers not found

### DIFF
--- a/src/packages.config
+++ b/src/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BepInEx.Analyzers" version="1.0.7" targetFramework="net472" developmentDependency="true" />
   <package id="BepInEx.BaseLib" version="5.4.16" targetFramework="net472" />
   <package id="HarmonyX" version="2.5.7" targetFramework="net472" />
   <package id="Mono.Cecil" version="0.11.4" targetFramework="net472" />


### PR DESCRIPTION
The [OutwardModTemplate.csproj](https://github.com/Mefino/OutwardModTemplate/blob/main/src/OutwardModTemplate.csproj#L346-L347) references `BepInEx.Analyzers.1.0.7` which are not present in `packages.config`, this results in a build failure. Adding the package to `packages.config` fixes the problem.